### PR TITLE
Add AI-SECRETT Machine Learning Workshop activity

### DIFF
--- a/content/activities/2026-03-11-ai-secrett-machine-learning-workshop.md
+++ b/content/activities/2026-03-11-ai-secrett-machine-learning-workshop.md
@@ -1,0 +1,25 @@
+---
+type: activity
+title: "AI-SECRETT Machine Learning Workshop"
+layout: activity.liquid
+startDate: 2026-03-11T16:00:00.000Z
+endDate: 2026-03-13T16:30:00.000Z
+location: "Sint Lucas Antwerpen"
+thumbnail: https://imagedelivery.net/7-GLn6-56OyK7JwwGe0hfg/slarg/1a87b3eb236d4bbc5172bd353b69dda7fd537181.png
+tags: []
+research_interests:
+  - ai
+  - generative design
+people:
+  - Frederik De Bleser
+external_collaborators:
+  - name: Algorithmic Gaze
+    url: https://algorithmicgaze.com/
+---
+SLARG and the [Algorithmic Gaze](https://algorithmicgaze.com/) research group welcome international guests from the [AI-SECRETT](https://ai-secrett.eu/) consortium for a three-day machine learning workshop at Sint Lucas Antwerpen.
+
+The workshop brings together researchers and artists to explore how machine learning can be used as a creative tool. Participants will train custom image models and learn to make them interactive using [Figment](https://figmentapp.com/), an open-source tool for building real-time ML applications developed by the Algorithmic Gaze research group.
+
+The programme opens on Wednesday evening with a warm-up performance, followed by two intensive hands-on workshop days focused on image generation, model training, and creative experimentation.
+
+This workshop is part of an ongoing international collaboration between art and design institutions investigating the role of artificial intelligence in creative practice.


### PR DESCRIPTION
## Summary
- **Fix Eleventy v3 build errors**: reserved `content` data property, broken Liquid syntax in `_eventGrid2.liquid`, and local image path support in templates
- **Add AI-SECRETT ML Workshop activity** (March 11–13, 2026): public-facing post about the three-day workshop with AI-SECRETT consortium guests, hosted by SLARG and Algorithmic Gaze at Sint Lucas Antwerpen
- Thumbnail uploaded to Cloudflare Images via the existing Netlify function

## Test plan
- [ ] Verify the activities calendar page shows the new event with thumbnail
- [ ] Verify the activity detail page renders correctly with date range, location, researcher, and body content
- [ ] Confirm existing activities and research week pages still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)